### PR TITLE
chore(ci): improve npm publish logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "cargo clean && rimraf lib",
     "build": "pnpm clean && ./scripts/cross-build.sh && tsup-node",
     "build:debug": "pnpm clean && napi build --platform lib && tsup-node",
-    "prepublishOnly": "pnpm build"
+    "prepublishOnly": "./scripts/prepublish-only.sh"
   },
   "devDependencies": {
     "@napi-rs/cli": "^1.0.0",

--- a/scripts/cross-build.sh
+++ b/scripts/cross-build.sh
@@ -5,6 +5,6 @@ platform_list=("x86_64-apple-darwin" "aarch64-apple-darwin")
 
 for platform in "${platform_list[@]}"
 do
-    echo "napi build --platform --target $platform --release lib"
-    napi build --platform --target $platform --release lib
+    echo "pnpm exec napi build --platform --target $platform --release lib"
+    pnpm exec napi build --platform --target $platform --release lib
 done

--- a/scripts/prepublish-only.sh
+++ b/scripts/prepublish-only.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o pipefail
+
+if [ -z $CI]; then
+    pnpm run build;
+else
+    exit 0;
+fi;


### PR DESCRIPTION
In CI, if the build artifacts already exist, there should be no need to build again.